### PR TITLE
Fix msvc compilation

### DIFF
--- a/VkRaven/raven/include/raven/core/GPUContext.h
+++ b/VkRaven/raven/include/raven/core/GPUContext.h
@@ -125,7 +125,7 @@ namespace raven {
             m_activeIndex = (m_activeIndex + 1) % MAX_FRAMES_IN_FLIGHT;
         }
 
-        std::chrono::time_point<std::chrono::system_clock> m_time = std::chrono::high_resolution_clock::now();
+        std::chrono::time_point<std::chrono::steady_clock> m_time = std::chrono::high_resolution_clock::now();
 
     private:
 #ifdef NDEBUG

--- a/VkRaven/raven/include/raven/passes/ImGuiPass.h
+++ b/VkRaven/raven/include/raven/passes/ImGuiPass.h
@@ -43,7 +43,8 @@ namespace raven {
             renderPassInfo.renderArea.extent = m_swapChain->getSwapchainExtent();
 
             std::array<vk::ClearValue, 2> clearValues{};
-            clearValues[0].color = {vk::ClearColorValue(0.0f, 0.0f, 0.0f, 1.0f)};
+            std::array<float, 4> black = { 0.0f, 0.0f, 0.0f, 1.0f };
+            clearValues[0].color = {vk::ClearColorValue(black)};
             clearValues[1].depthStencil = vk::ClearDepthStencilValue{1.0f, 0}; // depth in [0,1] where 1 is at the far view plane
             renderPassInfo.clearValueCount = static_cast<uint32_t>(clearValues.size());
             renderPassInfo.pClearValues = clearValues.data();

--- a/VkRaven/raven/include/raven/scene/RavenScene.h
+++ b/VkRaven/raven/include/raven/scene/RavenScene.h
@@ -7,6 +7,8 @@
 #include "RavenTexture.h"
 #include "raven/core/GPUContext.h"
 
+#include <map>
+
 namespace raven {
     class RavenScene {
     public:


### PR DESCRIPTION
Commit 21b207fcca9e09a46928dbea51351c7140eba569 fixes compilation on MSVC 19.41.34120 (Visual Studio 17.11.2)

Commit 38de8cdcb2d0f1362a176295bfa26c4dd13343c6 fixes compilation on GCC 14.1.0 + Ubuntu 22.0.1 where it seems `clearValues[0].color = {vk::ClearColorValue(0.0f, 0.0f, 0.0f, 1.0f)};` would not automatically interpret `(0.0f, 0.0f, 0.0f, 1.0f)` as an `std::array<float, 4>`